### PR TITLE
FIX : User Control Modal Exceiption 추가

### DIFF
--- a/src/modules/room/components/Team.tsx
+++ b/src/modules/room/components/Team.tsx
@@ -11,6 +11,8 @@ export const TeamComponent = ({ team, teamUsers, handleTeamClick, teamType }: an
   const [modalPosition, setModalPosition] = useState({ x: 0, y: 0 });
 
   const handleOpenModal = (user:any, e: React.MouseEvent<HTMLDivElement>) => {
+    // Exception
+    if(user == null) return;
     setIsModalOpen(true);
     setSelectedUser(user);
     console.log({ x: e.clientX, y: e.clientY });


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [] 기능 추가 <br>
- [] 기능 삭제 <br>
- [X] 버그 수정 <br>
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 💊버그 해결

준비방에서 비어있는 멤버 목록을 클릭시에도 모달이 떴는데, null일 경우에는 모달창이 뜨지 않도록 수정했습니다.

```
  const handleOpenModal = (user:any, e: React.MouseEvent<HTMLDivElement>) => {
    // Exception
    if(user == null) return;
    setIsModalOpen(true);
   <---생략--->
  };
 ```

<br>
 
