### PR TITLE
Feat : Multi User Ready CSS 구현

### DIFF
--- a/src/hook/useWebSocket.tsx
+++ b/src/hook/useWebSocket.tsx
@@ -8,11 +8,11 @@ export const useWebSocket = (roomId: string) => {
 
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
-    
+
 
     const [teamOneUsers, setTeamOneUsers] = useState<(TeamUser | null)[]>(Array(5).fill(null));
     const [teamTwoUsers, setTeamTwoUsers] = useState<(TeamUser | null)[]>(Array(5).fill(null));
-   
+
     // STOMP 클라이언트 설정 함수
     const setupStompClient = useCallback(() => {
         const client = new Client({
@@ -75,6 +75,20 @@ export const useWebSocket = (roomId: string) => {
         setTeamTwoUsers(filledRedTeam);
     };
 
+    // 유저 상태 변경 함수 추가
+    const updateUserStatus = (userId: string, status: 'READY' | 'NOT_READY') => {
+        if (!stompClient.current?.active) return;
+
+        stompClient.current.publish({
+            destination: '/quiz/multi/rooms/status', // 서버의 엔드포인트에 맞게 수정
+            body: JSON.stringify({
+                roomId,
+                userId,
+                status
+            })
+        });
+    };
+
     useEffect(() => {
         const client = setupStompClient();
         client.activate();
@@ -87,7 +101,7 @@ export const useWebSocket = (roomId: string) => {
         };
     }, [roomId, setupStompClient]);
 
-    return { isLoading, error, stompClient ,teamOneUsers,teamTwoUsers};
+    return { isLoading, error, stompClient, teamOneUsers, teamTwoUsers , updateUserStatus};
 };
 
 

--- a/src/modules/room/components/RoomButtons.tsx
+++ b/src/modules/room/components/RoomButtons.tsx
@@ -1,9 +1,30 @@
 import { PrimaryButtonMiddle, SecondaryButtonShort } from "../../../components/buttons/styled";
 import { RoomButtonWrap } from "../../../pages/multi/room/styled";
+import { useUser } from "../../../hook/user";
+import { useWebSocket } from "../../../hook/useWebSocket";
 
-export const RoomButtons = () => (
+interface RoomButtonsProps {
+  roomId: string;
+}
+
+export const RoomButtons = ({roomId}: RoomButtonsProps) => {
+  const { user } = useUser(); // storage에서 로그인된 유저 정보 가져오기.
+  const { updateUserStatus } = useWebSocket(roomId);
+
+  const MultiReadyButton = () => {    
+    // 해당 유저 READY상태로 API 요청 보내기.
+    console.log("준비 API 요청");
+  };
+
+  const MultiExitButton = () => {    
+    // 해당 유저 EXIT API 요청 보내기.
+    console.log("EXIT API 요청");
+    
+  };
+
+  return (
   <RoomButtonWrap>
-    <PrimaryButtonMiddle>Ready</PrimaryButtonMiddle>
-    <SecondaryButtonShort>나가기</SecondaryButtonShort>
-  </RoomButtonWrap>
-);
+    <PrimaryButtonMiddle onClick={MultiReadyButton}>Ready</PrimaryButtonMiddle>
+    <SecondaryButtonShort onClick={MultiExitButton}>나가기</SecondaryButtonShort>
+  </RoomButtonWrap>);
+};

--- a/src/modules/room/components/Team.tsx
+++ b/src/modules/room/components/Team.tsx
@@ -44,6 +44,7 @@ export const TeamComponent = ({ team, teamUsers, handleTeamClick, teamType }: an
             user={user}
             onClick={() => !user && handleTeamClick('blue')}
             teamType="blue"
+            state= {user?.state}
           />
           </div>
         ))}
@@ -72,6 +73,7 @@ export const TeamComponent = ({ team, teamUsers, handleTeamClick, teamType }: an
             user={user}
             onClick={() => !user && handleTeamClick('red')}
             teamType="red"
+            state= {user?.state}
           />
           </div>
         ))}

--- a/src/modules/room/components/TeamUser.tsx
+++ b/src/modules/room/components/TeamUser.tsx
@@ -18,17 +18,20 @@ import {
   RoomTeamLeaderIcon
 } from "../../../pages/multi/room/styled";
 import { User } from "../../../hook/user";
+import {ReadyText} from "./styled"
 
 // 공통으로 사용할 타입들을 먼저 정의
 export type UserRole = 'host' | 'guest';
 export type TeamRole = 'leader' | 'member';
 export type TeamType = 'red' | 'blue';
+export type UserState = 'ready' | 'notready';
 
 // Member 인터페이스 정의
 export interface TeamUser extends User {
   role: UserRole;
   isLeader: TeamRole;
   team: TeamType;
+  state: UserState;
 }
 
 // TeamUserProps는 Member를 활용하여 정의
@@ -36,18 +39,21 @@ export interface TeamUserProps {
   user: TeamUser | null;
   onClick: () => void;
   teamType: TeamType;
+  state: UserState;
 }
 
-export const TeamUserComponent = ({ user, onClick, teamType }: TeamUserProps) => {
+export const TeamUserComponent = ({ user, onClick, teamType, state }: TeamUserProps) => {
   const isRedTeam = teamType === 'blue';
   const isHost = user?.role === 'host'; // null 일수도 있어서 ?로 
   const isLeader = user?.isLeader === 'leader';
+  const isReady = state === 'ready';
 
   return isRedTeam ? (
     <RoomTeamOneUser onClick={onClick}>
       {user ? (
         <>
           <RoomTeamOneUserName>
+            {isReady && <ReadyText $align = 'left'>READY</ReadyText>}
             {isLeader && <RoomTeamLeaderIcon src="/icons/medal.svg" alt="Badge" />}
             {user.name}
             {isHost && <RoomHostIcon src="/icons/crown.svg" alt="Badge" />}
@@ -72,11 +78,12 @@ export const TeamUserComponent = ({ user, onClick, teamType }: TeamUserProps) =>
         <>
           <RoomTeamTwobackground />
           <RoomTeamTwoUserHonorWrap>
-              <RoomTeamTwoUserHonor>{user.honor}</RoomTeamTwoUserHonor>
-              <RoomTeamTwoUserHonorIcon src="/icons/badge.svg" alt="Badge" />
+            <RoomTeamTwoUserHonor>{user.honor}</RoomTeamTwoUserHonor>
+            <RoomTeamTwoUserHonorIcon src="/icons/badge.svg" alt="Badge" />
           </RoomTeamTwoUserHonorWrap>
           <RoomTeamTwoUserProfile src={user.profileImage} alt={user.name} />
           <RoomTeamTwoUserName>
+            {isReady && <ReadyText $align = 'right'>READY</ReadyText>}
             {isHost && <RoomTeamTwoUserHonorIcon src="/icons/badge.svg" alt="Badge" />}
             {user.name}
             {isLeader && <RoomTeamLeaderIcon src="/icons/medal.svg" alt="Badge" />}

--- a/src/modules/room/components/styled.ts
+++ b/src/modules/room/components/styled.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+export const ReadyText = styled.div<{
+    $align ?: string;
+  }>`
+  position: absolute;
+  left: ${({$align}) => $align === 'left' ? '0px' : 'none'};       
+  right : ${({$align}) => $align === 'right' ? '0px' : 'none'};
+  top: 50%;          // 세로 중앙 정렬
+  transform: translateY(-50%);  // 정확한 세로 중앙 정렬
+  text-align: ${({$align}) => $align === 'right' ? 'right' : 'left'};
+  font-style: italic;
+  font-weight: 900;
+  font-size: 30px;
+  background:  ${({$align}) => $align === 'left' ? 'linear-gradient(to right, #4061B5, #FFFF)' : 'linear-gradient(to left, #A82D3B, #FFFF)'}; 
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  padding : 10px;
+  flex-shrink: 0;      // 크기 유지
+  width: fit-content; // 내용물 만큼만 너비 차지
+`;

--- a/src/pages/multi/room/room.tsx
+++ b/src/pages/multi/room/room.tsx
@@ -37,8 +37,6 @@ export default function Room() {
   const { state } = useLocation();
   const { isLoading, error, stompClient,teamOneUsers,teamTwoUsers} = useWebSocket(roomId);
 
-  
-
   const handleTeamClick = (clickedTeam: string) => {
     const userUuid = localStorage.getItem('userUuid');
     if (!userUuid || !stompClient.current?.active) return;
@@ -108,7 +106,7 @@ export default function Room() {
       <RoomTeamContainer>
         <TeamComponent
           team="1팀"
-          teamUsers={testOneUsers}
+          teamUsers={testOneUsers} // 여기 있는 팀이 실시간 통신으로 업데이트 되어야함.
           handleTeamClick={handleTeamClick}
           teamType="blue"
         />
@@ -121,7 +119,7 @@ export default function Room() {
         />
 
       </RoomTeamContainer>
-      <RoomButtons />
+      <RoomButtons roomId = {roomId} />
     </Background>
   );
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 기능 추가 <br>
- [] 기능 삭제 <br>
- [] 버그 수정 <br>
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점
1. room button을 이벤트 함수와 연결 
```
export const RoomButtons = ({roomId}: RoomButtonsProps) => {
  const { user } = useUser(); // storage에서 로그인된 유저 정보 가져오기.
  const { updateUserStatus } = useWebSocket(roomId);

  const MultiReadyButton = () => {    
    // 해당 유저 READY상태로 API 요청 보내기.
    console.log("준비 API 요청");
  };

  const MultiExitButton = () => {    
    // 해당 유저 EXIT API 요청 보내기.
    console.log("EXIT API 요청");
    
  };

  return (
  <RoomButtonWrap>
    <PrimaryButtonMiddle onClick={MultiReadyButton}>Ready</PrimaryButtonMiddle>
    <SecondaryButtonShort onClick={MultiExitButton}>나가기</SecondaryButtonShort>
  </RoomButtonWrap>);
};
```
<br>

2. userTeam의 상태 정보(준비상태)를 받아서 값에 따라 Ready됨을 보이도록 수정함
```
<RoomTeamOneUserName>
            {isReady && <ReadyText $align = 'left'>READY</ReadyText>}
            {isLeader && <RoomTeamLeaderIcon src="/icons/medal.svg" alt="Badge" />}
            {user.name}
            {isHost && <RoomHostIcon src="/icons/crown.svg" alt="Badge" />}
          </RoomTeamOneUserName>
```


## 스크린샷
![image](https://github.com/user-attachments/assets/b6f1f371-bf42-47ab-b295-69a9d770cb08)

