### PR TITLE
68 멀티 모드 roomid 받는 api 만들기 및 여러 이벤트 함수

### DIFF
--- a/src/components/modal/room/index.tsx
+++ b/src/components/modal/room/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState,useEffect } from "react"
 import { useNavigate } from 'react-router-dom';
 import { Modal, IModalProps } from ".."
 import { PrimaryButtonMedium, SecondaryButton } from "../../buttons/styled"
@@ -12,7 +12,8 @@ export const CreateRoomModal = ({
     const [value, setValue] = useState(4);
     const [isPasswordChecked, setIsPasswordChecked] = useState(false);
     const [isNoPasswordChecked, setIsNoPasswordChecked] = useState(true);
-    const [roomId, setRoomId] = useState<string>('');
+    const [roomId, setRoomId] = useState<number>(0);
+    const [roomName, setRoomName] = useState<string>();
     const navigate = useNavigate();
 
     const handleNoPasswordCheckbox = () => {
@@ -32,11 +33,11 @@ export const CreateRoomModal = ({
     //TODO: 방 만들기
     const handleCreateRoom = async () => {
         const userUuid = localStorage.getItem("uuid");
-        const roomName = (document.getElementById("roomName") as HTMLInputElement).value;
+        const NroomName = (document.getElementById("roomName") as HTMLInputElement).value;
         const roomPassword = (document.getElementById("password") as HTMLInputElement).value;
         const participants = Number((document.getElementById("participants") as HTMLInputElement).value);
        
-        if(!roomName){
+        if(!NroomName){
             alert("방 이름을 입력하지 않았습니다. 입력해주세요.");
             return;
         }
@@ -63,7 +64,7 @@ export const CreateRoomModal = ({
         }
 
         const roomData = {
-            name: roomName,
+            name: NroomName,
             password: isPasswordChecked? roomPassword: null,
             maxUser: participants,
             uuid: userUuid,
@@ -84,20 +85,25 @@ export const CreateRoomModal = ({
 
             const responseData = await response.json();
             console.log(responseData);
-            console.log("성공");
+            console.log(responseData.data.roomId);
            
-            setRoomId(responseData.data.roomId); // 이거 응답 파싱 틀렸을수도있음
-     
-            // navigate 사용
-            navigate(`/room/${roomId}`, {
-                state: { roomId: roomId, roomName : roomName}
-            });
+            setRoomId(responseData.data.roomId); 
+            setRoomName(NroomName);
+            console.log(roomId);
         }
         catch (error){
             console.error("방 생성 에러", error);
             alert("방을 생성하지 못했습니다. 잠시후 다시 시도해주세요.")
         }
     };   
+
+    useEffect(() => {
+        if (roomId) {
+          navigate(QUIZ_MULTI_ENDPOINTS.ROOMS.JOIN(roomId), {
+            state: { roomId: roomId, roomName : roomName },
+          });
+        }
+      }, [roomId, navigate, roomName]);
 
     return(
         <Modal {...props} >

--- a/src/components/modal/room/index.tsx
+++ b/src/components/modal/room/index.tsx
@@ -1,4 +1,4 @@
-import { useState,useEffect } from "react"
+import { useState, useEffect } from "react"
 import { useNavigate } from 'react-router-dom';
 import { Modal, IModalProps } from ".."
 import { PrimaryButtonMedium, SecondaryButton } from "../../buttons/styled"
@@ -27,23 +27,23 @@ export const CreateRoomModal = ({
     }
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      setValue(Number(e.target.value));
+        setValue(Number(e.target.value));
     };
 
     //TODO: 방 만들기
     const handleCreateRoom = async () => {
-        const userUuid = localStorage.getItem("uuid");
+        const userUuid = "91f89030-e522-496f-afd8-015c42e501f3";
         const NroomName = (document.getElementById("roomName") as HTMLInputElement).value;
         const roomPassword = (document.getElementById("password") as HTMLInputElement).value;
         const participants = Number((document.getElementById("participants") as HTMLInputElement).value);
-       
-        if(!NroomName){
+
+        if (!NroomName) {
             alert("방 이름을 입력하지 않았습니다. 입력해주세요.");
             return;
         }
         // 비번 체크 됐지만 입력이 없을 때 경고창
-        if(isPasswordChecked){
-            if(!roomPassword){
+        if (isPasswordChecked) {
+            if (!roomPassword) {
                 alert("비밀번호를 입력해주세요.");
                 return;
             }
@@ -52,12 +52,12 @@ export const CreateRoomModal = ({
 
             // 숫자인지 확인
             const isNumber = /^\d+$/.test(roomPasswordStr);
-            if(!isNumber){
+            if (!isNumber) {
                 alert("숫자를 입력하세요.");
                 return;
             }
 
-            if(roomPasswordStr.length < 4 || roomPasswordStr.length > 12){
+            if (roomPasswordStr.length < 4 || roomPasswordStr.length > 12) {
                 alert("4자리 이상 12자리 미만의 숫자를 입력하세요.");
                 return;
             }
@@ -65,7 +65,7 @@ export const CreateRoomModal = ({
 
         const roomData = {
             name: NroomName,
-            password: isPasswordChecked? roomPassword: null,
+            password: isPasswordChecked ? roomPassword : null,
             maxUser: participants,
             uuid: userUuid,
         };
@@ -79,59 +79,58 @@ export const CreateRoomModal = ({
                 body: JSON.stringify(roomData),
             });
 
-            if(!response.ok){
+            if (!response.ok) {
                 throw new Error("방 생성에 실패하였습니다.");
             }
 
             const responseData = await response.json();
             console.log(responseData);
             console.log(responseData.data.roomId);
-           
-            setRoomId(responseData.data.roomId); 
+            setRoomId(responseData.data.roomId);
             setRoomName(NroomName);
             console.log(roomId);
-        }
-        catch (error){
+        } catch (error) {
             console.error("방 생성 에러", error);
-            alert("방을 생성하지 못했습니다. 잠시후 다시 시도해주세요.")
+            alert("방을 생성하지 못했습니다. 잠시후 다시 시도해주세요.");
         }
-    };   
+    };
 
     useEffect(() => {
         if (roomId) {
-          navigate(QUIZ_MULTI_ENDPOINTS.ROOMS.JOIN(roomId), {
-            state: { roomId: roomId, roomName : roomName },
-          });
+            navigate(`/room/${roomId}`, {
+                state: { roomId: roomId, roomName: roomName },
+            });
         }
-      }, [roomId, navigate, roomName]);
+    }, [roomId, navigate, roomName]);
 
-    return(
+
+    return (
         <Modal {...props} >
             <ModalTitleWrap>
-                <ModalTitleIcon src="/icons/mdi_users_black.svg" alt="Create Room Icon"/>
+                <ModalTitleIcon src="/icons/mdi_users_black.svg" alt="Create Room Icon" />
                 <ModalTitle>MULTI MODE</ModalTitle>
             </ModalTitleWrap>
             <CreateRoomModalBodyWrap>
                 <CreateRoomModalRow>
                     <CreateRoomModalLabel>방이름</CreateRoomModalLabel>
-                    <CreateRoomModalInput id="roomName" placeholder="방 이름을 입력해주세요"/>
+                    <CreateRoomModalInput id="roomName" placeholder="방 이름을 입력해주세요" />
                 </CreateRoomModalRow>
                 <CreateRoomModalRowContainer>
                     <CreateRoomModalRow>
                         <CreateRoomModalLabel>비밀번호</CreateRoomModalLabel>
                         <CreateRoomModalPasswordWrap>
                             <CreateRoomModalPasswordRow onClick={handleNoPasswordCheckbox}>
-                                <CreateRoomModalPasswordCheckbox 
-                                src={isNoPasswordChecked ? "/icons/checkbox_filled.svg" : "/icons/checkbox_base.svg"} 
-                                alt="Checkbox No Password"/>
+                                <CreateRoomModalPasswordCheckbox
+                                    src={isNoPasswordChecked ? "/icons/checkbox_filled.svg" : "/icons/checkbox_base.svg"}
+                                    alt="Checkbox No Password" />
                                 <CreateRoomModalText>사용안함</CreateRoomModalText>
                             </CreateRoomModalPasswordRow>
                             <CreateRoomModalPasswordRow onClick={handlePasswordCheckbox}>
-                                <CreateRoomModalPasswordCheckbox 
-                                src={isPasswordChecked ? "/icons/checkbox_filled.svg" : "/icons/checkbox_base.svg"} 
-                                alt="Checkbox Use Password"/>
-                                <CreateRoomModalPasswordInput  
-                                disabled={!isPasswordChecked} id="password" placeholder="4자리 이상 숫자를 입력해주세요"/>
+                                <CreateRoomModalPasswordCheckbox
+                                    src={isPasswordChecked ? "/icons/checkbox_filled.svg" : "/icons/checkbox_base.svg"}
+                                    alt="Checkbox Use Password" />
+                                <CreateRoomModalPasswordInput
+                                    disabled={!isPasswordChecked} id="password" placeholder="4자리 이상 숫자를 입력해주세요" />
                             </CreateRoomModalPasswordRow>
                         </CreateRoomModalPasswordWrap>
                     </CreateRoomModalRow>
@@ -142,12 +141,12 @@ export const CreateRoomModal = ({
                                 type="number"
                                 id="participants"
                                 name="participants"
-                                min="4" 
+                                min="4"
                                 max="10"
                                 value={value}
-                                onChange={handleChange}/>
+                                onChange={handleChange} />
                             <CreateRoomModalNumberInfo>
-                                <CreateRoomModalNumberInfoImg src="/icons/info.svg" alt="Info Icon"/>
+                                <CreateRoomModalNumberInfoImg src="/icons/info.svg" alt="Info Icon" />
                                 <CreateRoomModalNumberInfoText>최대 10명까지 입장할 수 있습니다.</CreateRoomModalNumberInfoText>
                             </CreateRoomModalNumberInfo>
                         </CreateRoomModalNumberWrap>

--- a/src/config/api/endpoints/quiz-multi.endpoints.ts
+++ b/src/config/api/endpoints/quiz-multi.endpoints.ts
@@ -7,17 +7,18 @@ export const QUIZ_MULTI_ENDPOINTS = {
     ROOMS: {
         LIST: quizMultiEndpoints.create('/rooms'), //GET
         PWCHECK: quizMultiEndpoints.create('/rooms/check'), //POST
-        JOIN: (roomId: string) => quizMultiEndpoints.createWithParams('/rooms/:roomId', { roomId }), //GET
+        JOIN: (roomId: number) => `/room/${ roomId }`, //GET
         CREATE: quizMultiEndpoints.create('/rooms/create') //POST
     },
-    ROOM:{
+    ROOM: {
         CREATE: quizMultiEndpoints.create('/rooms'), //POST
+        JOIN: quizMultiEndpoints.create('/rooms/join'), //POST
         TEAM_CHANGE: quizMultiEndpoints.create('/team-switch'), //POST
         READY: quizMultiEndpoints.create('/ready'), //POST
         KICK: quizMultiEndpoints.create('/ready'), //POST
         EXIT: quizMultiEndpoints.create('/exit') //POST
     },
-    YEILD:{
+    YEILD: {
         HOST: quizMultiEndpoints.create('/yield-host'), //POST
         LEADER: quizMultiEndpoints.create('/yield-leader'), //POST
     },

--- a/src/config/api/endpoints/quiz-multi.endpoints.ts
+++ b/src/config/api/endpoints/quiz-multi.endpoints.ts
@@ -7,7 +7,6 @@ export const QUIZ_MULTI_ENDPOINTS = {
     ROOMS: {
         LIST: quizMultiEndpoints.create('/rooms'), //GET
         PWCHECK: quizMultiEndpoints.create('/rooms/check'), //POST
-        JOIN: (roomId: number) => `/room/${ roomId }`, //GET
         CREATE: quizMultiEndpoints.create('/rooms/create') //POST
     },
     ROOM: {

--- a/src/config/websocket/constants.ts
+++ b/src/config/websocket/constants.ts
@@ -4,7 +4,7 @@ export const SOCKET_DESTINATIONS = {
             // 구독할 토픽
             SUBSCRIBE: {
                 ROOM_INFO: (roomId: string) => `/topic/rooms/${roomId}/info`,
-                USER_ENTER: (roomId: string) => `/topic/rooms/${roomId}/enter`
+                USER_JOIN: `/queue/rooms/join`
             },
 
             REQUEST: {

--- a/src/hook/socketEvent.tsx
+++ b/src/hook/socketEvent.tsx
@@ -12,9 +12,7 @@ export const socketEvents = {
                 SOCKET_DESTINATIONS.QUIZ_MULTI.ROOMS.SUBSCRIBE.ROOM_INFO(roomId),
                 (message) => {
                     console.log('Received message:', message);
-                    try {
-                        
-                        
+                    try {      
                         interface ServerUser {
                             roomUserId: number;  // string이 아닌 number
                             username: string;
@@ -60,7 +58,7 @@ export const socketEvents = {
 
         const destination = SOCKET_DESTINATIONS.QUIZ_MULTI.ROOMS.SEND.JOIN;
         const message = {
-            uuid: "8abd487f-6409-4e22-b101-942401c43d0d", // 수정 요!
+            uuid: "f60680e5-c3d9-42fe-830e-9e8199a0cdb8", // 수정 요!
             roomId: roomId,
         };
 

--- a/src/hook/useRoom.tsx
+++ b/src/hook/useRoom.tsx
@@ -1,21 +1,28 @@
 import { Client } from '@stomp/stompjs';
-import { useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { socketEvents } from './socketEvent';
 import { useTeamState } from './useTeamState';
 import { UseWebSocket } from './useWebSocket';
 import { useNavigate } from 'react-router-dom';
 import { SERVICES } from '../config/api/constants';
+import { useRoomUerId } from './useRoomUserId';
 
 export const useRoom = (roomId: string) => {
     const { teamOneUsers, teamTwoUsers, updateTeams } = useTeamState(roomId);
     const { stompClient, isConnected, connect } = UseWebSocket(roomId, false);
+    const [isEntry, setIsEntry] = useState(false);
+    const { roomUserId, initRoomUserID } = useRoomUerId();
 
     const navigate = useNavigate();
 
     // 구독 로직
     const setupSubscriptions = useCallback((client: Client) => {
         console.log('Setting up room subscriptions');
+        socketEvents.subscribeRoomUserId(client, "bd79f530-ea82-4487-bd3a-9240e517e39a", initRoomUserID);
+
         socketEvents.subscribeToRoom(client, roomId, updateTeams);
+
+
     }, [roomId, updateTeams]);
 
     // 입장 로직
@@ -71,14 +78,16 @@ export const useRoom = (roomId: string) => {
     };
 
     useEffect(() => {
+
         enterRoom(); // Active Socket Protocol 
+
 
         return () => {
             if (stompClient.current?.active) {
                 stompClient.current.deactivate();
             }
         };
-    }, []);
+    }, [roomId]);
 
     // 디버깅을 위한 상태 변화 감지
     useEffect(() => {
@@ -89,6 +98,7 @@ export const useRoom = (roomId: string) => {
     }, [teamOneUsers, teamTwoUsers]);
 
     return {
+        roomUserId,
         teamOneUsers,
         teamTwoUsers,
         exitRoom,

--- a/src/hook/useRoom.tsx
+++ b/src/hook/useRoom.tsx
@@ -9,7 +9,9 @@ import { SERVICES } from '../config/api/constants';
 export const useRoom = (roomId: string) => {
     const { teamOneUsers, teamTwoUsers, updateTeams } = useTeamState(roomId);
     const { stompClient, isConnected, connect } = UseWebSocket(roomId, false);
+
     const navigate = useNavigate();
+
     // 구독 로직
     const setupSubscriptions = useCallback((client: Client) => {
         console.log('Setting up room subscriptions');
@@ -34,11 +36,14 @@ export const useRoom = (roomId: string) => {
             console.error('Room entry failed:', error);
             throw error;
         }
+
+
+
     }, [roomId, isConnected, connect, setupSubscriptions]);
 
-    const exitRoom = async () => {
+    const exitRoom = async (roomUserId: string) => {
         try {
-            await socketEvents.userExitRoom(stompClient, "13", roomId); // 수정 요!
+            await socketEvents.userExitRoom(stompClient, roomUserId, roomId); // 수정 요!
         } catch (error) {
             console.error('Room exit failed:', error);
             throw error;
@@ -47,17 +52,26 @@ export const useRoom = (roomId: string) => {
         navigate(SERVICES.MULTI);
     };
 
-    const userReady = async () => {
+    const userReady = async (roomUserId: string) => {
         try {
-            await socketEvents.updateUserState(stompClient, "13", roomId); // 수정 요!
+            await socketEvents.updateUserState(stompClient, roomUserId, roomId); // 수정 요!
         } catch (error) {
             console.error('User ready failed:', error);
             throw error;
         }
-    }
+    };
+
+    const teamSwitch = async (clickedTeam: string) => {
+        try {
+            // todo : team switch socket protocol
+        } catch (error) {
+            console.error('Team switch failed:', error);
+            throw error;
+        }
+    };
 
     useEffect(() => {
-        enterRoom();
+        enterRoom(); // Active Socket Protocol 
 
         return () => {
             if (stompClient.current?.active) {
@@ -78,6 +92,7 @@ export const useRoom = (roomId: string) => {
         teamOneUsers,
         teamTwoUsers,
         exitRoom,
-        userReady
+        userReady,
+        teamSwitch,
     };
 };

--- a/src/hook/useRoomUserId.tsx
+++ b/src/hook/useRoomUserId.tsx
@@ -1,0 +1,15 @@
+import { useState, useCallback } from "react";
+
+export const useRoomUerId = () => {
+    const [roomUserId , setRoomUserId ] = useState("");
+
+    const initRoomUserID = (roomUid: string) => {
+        setRoomUserId(roomUid);
+    };
+
+
+    return {
+        roomUserId,
+        initRoomUserID
+    };
+};

--- a/src/hook/useWebSocket.tsx
+++ b/src/hook/useWebSocket.tsx
@@ -19,7 +19,7 @@ export const UseWebSocket = (roomId: string, autoConnect: boolean = false) => {
     // 기본 STOMP 클라이언트 설정
     const setupStompClient = useCallback(() => {
         return new Client({
-            brokerURL: 'ws://dev.cquis.net:8080/ws',
+            brokerURL: 'wss://dev.cquis.net:8080/ws',
             connectHeaders: {
                 roomId: roomId,
             },

--- a/src/hook/useWebSocket.tsx
+++ b/src/hook/useWebSocket.tsx
@@ -19,7 +19,7 @@ export const UseWebSocket = (roomId: string, autoConnect: boolean = false) => {
     // 기본 STOMP 클라이언트 설정
     const setupStompClient = useCallback(() => {
         return new Client({
-            brokerURL: 'wss://dev.cquis.net:8080/ws',
+            brokerURL: 'ws://dev.cquis.net:8080/ws',
             connectHeaders: {
                 roomId: roomId,
             },

--- a/src/modules/room/components/RoomButtons.tsx
+++ b/src/modules/room/components/RoomButtons.tsx
@@ -1,22 +1,31 @@
 import { PrimaryButtonMiddle, SecondaryButtonShort } from "../../../components/buttons/styled";
 import { RoomButtonWrap } from "../../../pages/multi/room/styled";
-import { useUser } from "../../../hook/user";
-import { UseWebSocket } from "../../../hook/useWebSocket";
-import { QUIZ_MULTI_ENDPOINTS } from "../../../config/api/endpoints/quiz-multi.endpoints";
+
 
 interface RoomButtonsProps {
-  roomId: string;
-  MultiReadyButton: () => void;
-  MultiExitButton: () => void
+  userRoomId: string;
+  MultiReadyButton: (userRoomId: string) => void;
+  MultiExitButton: (userRoomId: string) => void
 }
 
-export const RoomButtons = ({ roomId,MultiReadyButton,MultiExitButton }: RoomButtonsProps) => {
-  const { user } = useUser(); // storage에서 로그인된 유저 정보 가져오기.
-  //const { updateUserStatus } = useWebSocket(roomId);
+export const RoomButtons = ({
+  userRoomId,
+  MultiReadyButton,
+  MultiExitButton
+}: RoomButtonsProps) => {
+
+  const handleReadyClick = () => {
+    MultiReadyButton(userRoomId);
+  };
+
+  const handleExitClick = () => {
+    MultiExitButton(userRoomId);
+  };
+
 
   return (
     <RoomButtonWrap>
-      <PrimaryButtonMiddle onClick={MultiReadyButton}>Ready</PrimaryButtonMiddle>
-      <SecondaryButtonShort onClick={MultiExitButton}>나가기</SecondaryButtonShort>
+      <PrimaryButtonMiddle onClick={handleReadyClick}>Ready</PrimaryButtonMiddle>
+      <SecondaryButtonShort onClick={handleExitClick}>나가기</SecondaryButtonShort>
     </RoomButtonWrap>);
 };

--- a/src/pages/multi/room/room.tsx
+++ b/src/pages/multi/room/room.tsx
@@ -6,13 +6,11 @@ import { RoomTitleComponent } from '../../../modules/room/components/RoomTItle';
 import { TeamComponent } from '../../../modules/room/components/Team';
 import { RoomTeamContainer } from './styled';
 import { useRoom } from '../../../hook/useRoom';
-import { QUIZ_MULTI_ENDPOINTS } from '../../../config/api/endpoints/quiz-multi.endpoints';
 
 export default function Room() {
-  const [userRoomID, setUserRoomId] = useState('');
   const { roomId } = useLocation().state;
   const { state } = useLocation();
-  const { teamOneUsers, teamTwoUsers, userReady, exitRoom, teamSwitch } = useRoom(roomId);
+  const { roomUserId, teamOneUsers, teamTwoUsers, userReady, exitRoom, teamSwitch } = useRoom(roomId);
 
 
 
@@ -35,7 +33,7 @@ export default function Room() {
         />
 
       </RoomTeamContainer>
-      <RoomButtons userRoomId={userRoomID} MultiReadyButton={userReady} MultiExitButton={exitRoom} />
+      <RoomButtons userRoomId={roomUserId} MultiReadyButton={userReady} MultiExitButton={exitRoom} />
     </Background>
   );
 }

--- a/src/pages/multi/room/room.tsx
+++ b/src/pages/multi/room/room.tsx
@@ -14,30 +14,6 @@ export default function Room() {
   const { state } = useLocation();
   const { teamOneUsers, teamTwoUsers, userReady, exitRoom, teamSwitch } = useRoom(roomId);
 
-  useEffect(() => {
-    setUserRoomId("14");
-   /* const fetchRoomUserId = async () => {
-      try {
-        // REST API 호출 코드
-        const response = await fetch(QUIZ_MULTI_ENDPOINTS.ROOM.JOIN, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ 
-            "uuid": "95ba7632-28a2-470d-9464-24c4219e070f",
-          }),
-        });
-        const data = await response.json();
-        setUserRoomId(data.roomUserId);
-      } catch (error) {
-        console.error('Get UserRoomId failed', error);
-        throw error;
-      }
-    };
-
-    fetchRoomUserId();*/
-  }, [roomId]);
 
 
   return (

--- a/src/pages/multi/room/room.tsx
+++ b/src/pages/multi/room/room.tsx
@@ -1,21 +1,45 @@
 import { useLocation } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 import { Background } from '../../../components/background/styled';
 import { RoomButtons } from '../../../modules/room/components/RoomButtons';
 import { RoomTitleComponent } from '../../../modules/room/components/RoomTItle';
 import { TeamComponent } from '../../../modules/room/components/Team';
 import { RoomTeamContainer } from './styled';
 import { useRoom } from '../../../hook/useRoom';
+import { QUIZ_MULTI_ENDPOINTS } from '../../../config/api/endpoints/quiz-multi.endpoints';
 
 export default function Room() {
+  const [userRoomID, setUserRoomId] = useState('');
   const { roomId } = useLocation().state;
   const { state } = useLocation();
+  const { teamOneUsers, teamTwoUsers, userReady, exitRoom, teamSwitch } = useRoom(roomId);
 
-  const { teamOneUsers, teamTwoUsers , userReady , exitRoom} = useRoom(roomId);
+  useEffect(() => {
+    setUserRoomId("14");
+   /* const fetchRoomUserId = async () => {
+      try {
+        // REST API 호출 코드
+        const response = await fetch(QUIZ_MULTI_ENDPOINTS.ROOM.JOIN, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ 
+            "uuid": "95ba7632-28a2-470d-9464-24c4219e070f",
+          }),
+        });
+        const data = await response.json();
+        setUserRoomId(data.roomUserId);
+      } catch (error) {
+        console.error('Get UserRoomId failed', error);
+        throw error;
+      }
+    };
 
-  
-  const handleTeamClick = (clickedTeam: string) => {
+    fetchRoomUserId();*/
+  }, [roomId]);
 
-  }
+
   return (
     <Background>
       <RoomTitleComponent roomName={state?.roomName} />
@@ -23,19 +47,19 @@ export default function Room() {
         <TeamComponent
           team="1팀"
           teamUsers={teamOneUsers} // 여기 있는 팀이 실시간 통신으로 업데이트 되어야함.
-          handleTeamClick={handleTeamClick}
+          handleTeamClick={teamSwitch}
           teamType="blue"
         />
         <img src='/icons/VS.svg' alt='VS' />
         <TeamComponent
           team="2팀"
           teamUsers={teamTwoUsers}
-          handleTeamClick={handleTeamClick}
+          handleTeamClick={teamSwitch}
           teamType="red"
         />
 
       </RoomTeamContainer>
-      <RoomButtons roomId={roomId} MultiReadyButton = {userReady} MultiExitButton = {exitRoom}/>
+      <RoomButtons userRoomId={userRoomID} MultiReadyButton={userReady} MultiExitButton={exitRoom} />
     </Background>
   );
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [X] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점
1. 방 입장 시 REST API로 roomUserId를 받아오는 함수를 작성
서버 배포가 아직 안되어서, 일단 주석 처리 했습니다!
```
  useEffect(() => {
    setUserRoomId("14");
   /* const fetchRoomUserId = async () => {
      try {
        // REST API 호출 코드
        const response = await fetch(QUIZ_MULTI_ENDPOINTS.ROOM.JOIN, {
          method: 'POST',
          headers: {
            'Content-Type': 'application/json',
          },
          body: JSON.stringify({ 
            "uuid": "95ba7632-28a2-470d-9464-24c4219e070f",
          }),
        });
        const data = await response.json();
        setUserRoomId(data.roomUserId);
      } catch (error) {
        console.error('Get UserRoomId failed', error);
        throw error;
      }
    };

    fetchRoomUserId();*/
  }, [roomId]);
```

2. Exit, ready 이벤트 함수에 roomUserId  인자로 넘겨주도록 수정 
 ```
const handleReadyClick = () => {
    MultiReadyButton(userRoomId);
  };

  const handleExitClick = () => {
    MultiExitButton(userRoomId);
  };


  return (
    <RoomButtonWrap>
      <PrimaryButtonMiddle onClick={handleReadyClick}>Ready</PrimaryButtonMiddle>
      <SecondaryButtonShort onClick={handleExitClick}>나가기</SecondaryButtonShort>
    </RoomButtonWrap>);
};
```

## 💊버그 해결
방 생성 이후 잘못된 라우트로 이동하는 오류가 있었음. @yongsoung 
1. 잘못된 라우팅 -> 수정✅
`JOIN: (roomId: number) => `/room/${ roomId }`, //GET`

2. 비동기 처리와 Navigate 함수의 호출 순서 미스
❌ 기존 방 생성 함수는, 방 이름을 입력 받고, REST  API를 요청하여 roomId를 서버로부터 받은 뒤, 응답을 받고
Navigate를 호출하여 페이지 이동을 했었음.
```
const handleCreateRoom = async () => {
        const userUuid = localStorage.getItem("uuid");
        const NroomName = (document.getElementById("roomName") as HTMLInputElement).value;
        const roomPassword = (document.getElementById("password") as HTMLInputElement).value;
        const participants = Number((document.getElementById("participants") as HTMLInputElement).value);
       
       <---- 방 생성 유효성 검사 ---->

        try {
            < ---  REST API 요청 ---> // await fetch 비동기 실행
         
            const responseData = await response.json(); //  fetch가 완료 될 때 까지 기다림
            console.log(responseData); // 응답을 받으면 실행
            console.log(responseData.data.roomId); // 응답을 받으면 실행
           
            setRoomId(responseData.data.roomId);  // 응답을 받으면 실행
            setRoomName(NroomName); // 비동기 실행
            console.log(roomId); // 비동기 실행

            navigate(QUIZ_MULTI_ENDPOINTS.ROOMS.JOIN(roomId), { // 비동기 실행
            state: { roomId: roomId, roomName : roomName },
          });
        }
        catch (error){
        }
    };   
```
fetch 를 통해 응답을 받지 못한 상황에서 아래의 코드들이 비동기적으로 실행되기 때문에, roomId는 값을 얻지 못하고 null 값으로 페이지 이동을 하게 된다.

⭕ 해결 방법
페이지 이동하는 로직은 응답을 받고 나서 실행되도록 `useEffect()` 훅을 사용해 실행 순서를 보장해줍니다.
UseEffect()를 사용하여 roomId의 상태 변화를 감지하면 그때 페이지 이동이 이루어지게 수정하였습니다.

```
  useEffect(() => {
        if (roomId) {
          navigate(QUIZ_MULTI_ENDPOINTS.ROOMS.JOIN(roomId), {
            state: { roomId: roomId, roomName : roomName },
          });
        }
      }, [roomId, navigate, roomName]);
```