### PR TITLE
Fix : mapping different protocool as  wss & ws

### DIFF
--- a/src/hook/useWebSocket.tsx
+++ b/src/hook/useWebSocket.tsx
@@ -15,11 +15,13 @@ export const UseWebSocket = (roomId: string, autoConnect: boolean = false) => {
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
- 
+
     // 기본 STOMP 클라이언트 설정
     const setupStompClient = useCallback(() => {
-        return new Client({
-            brokerURL: 'wss://dev.cquis.net:8080/ws',
+        const wsProtocol = window.location.protocol === "https:" ? "wss" : "ws";
+ 
+        return new Client({           
+            brokerURL: `${wsProtocol}://dev.cquis.net:8080/ws`,
             connectHeaders: {
                 roomId: roomId,
             },


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점
local or domain에 따라 자동으로 wsBroker의 URL이 "ws" 혹은 "wss"로 변경되어 라우트  되게 수정 
