### PR TITLE
Feat: Multi In game exit button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,7 +80,7 @@ function App() {
           }
         />
           <Route
-          path="/multi/defend/select"
+          path="/multi/defend/select/:id"
           element={
             <ProtectedRoute>
               <SelectAnswerPage />

--- a/src/hook/useGameState.tsx
+++ b/src/hook/useGameState.tsx
@@ -1,25 +1,30 @@
-import { useState } from "react";
+import { useState , useRef} from "react";
 import { GameStatus ,GameReadyEvents  } from "../types/game";
 
 
 export const UseGameState = () => {
     const [isAllReady, setisAllReady ] = useState(false); // 모두 준비가 됐는지 불값.
     const [countdown, setcountdown ] = useState(5); // 카운트 다운 시간 number
-
+    const [gameState, setGameState] = useState<GameStatus>(GameStatus.READY);
 
     const handleReadyRoomEvent = (event : string, time : number = 0) => {
+        
         switch(event){
             case GameReadyEvents.ALL_READY:
                 setcountdown(time);
                 setisAllReady(true);
+                setGameState(GameStatus.READY);
                 break;
             case GameReadyEvents.STOP_READY:
                 setcountdown(time);
                 setisAllReady(false);
+                setGameState(GameStatus.READY);
                 break;
             case GameReadyEvents.GAME_START:
                 // Local Storage에 게임 정보 저장
                 // 그래야지 재 접속했을 때 다시 들어올 수 있음.
+                setGameState(GameStatus.START);
+                // 나중에 지울수도 있음.
                 localStorage.setItem("GameState", JSON.stringify(`${GameStatus.START}`));
                 break;
         }
@@ -27,6 +32,7 @@ export const UseGameState = () => {
 
 
     return {
+        gameState,
         isAllReady,
         countdown,
         handleReadyRoomEvent

--- a/src/hook/useRoom.tsx
+++ b/src/hook/useRoom.tsx
@@ -127,7 +127,6 @@ export const useRoom = (roomId: string) => {
     };
 
 
-    // TODO: Team 나눠서 페이지 이동하는 함수 
     const navigateToGamePage = async () => {
         //GameStart 상태로 만들어줌.
         handleReadyRoomEvent(GameReadyEvents.GAME_START);

--- a/src/hook/useRoom.tsx
+++ b/src/hook/useRoom.tsx
@@ -6,13 +6,13 @@ import { UseWebSocket } from './useWebSocket';
 import { useNavigate } from 'react-router-dom';
 import { SERVICES } from '../config/api/constants';
 import { UseGameState } from './useGameState';
-import { GameReadyEvents } from '../types/game';
+import { GameReadyEvents, GameStatus } from '../types/game';
 
 export const useRoom = (roomId: string) => {
     const { teamOneUsers, teamTwoUsers, updateTeams } = useTeamState(roomId);
     const { stompClient, isConnected, connect } = UseWebSocket(roomId, false);
     const Connected = useRef(false);  // 연결 상태 체크용
-    const { isAllReady, countdown, handleReadyRoomEvent } = UseGameState();
+    const { gameState ,isAllReady, countdown, handleReadyRoomEvent } = UseGameState();
     const navigate = useNavigate();
     const userUuid = localStorage.getItem("uuid");
 
@@ -128,15 +128,22 @@ export const useRoom = (roomId: string) => {
 
 
     // TODO: Team 나눠서 페이지 이동하는 함수 
-    const navigateToTeamPage = async () => {
-        // Local Storage에 Game State를 Start로 저장해준다.
+    const navigateToGamePage = async () => {
+        //GameStart 상태로 만들어줌.
         handleReadyRoomEvent(GameReadyEvents.GAME_START);
 
-        // TODO: Team 별로 Subscribe 설정.
+        // Navigate Game Page
+        navigate("/multi/game", {
+            state: {
+                roomId
+            }
+        });
     };
 
 
     useEffect(() => {
+        // 게임 준비 상태일 때만. 해당 훅을 실행한다.
+        if(gameState !== GameStatus.READY) return;
         if (Connected.current) return;
         const initializeRoom = async () => {
             try {
@@ -170,7 +177,7 @@ export const useRoom = (roomId: string) => {
         exitRoom,
         userReady,
         teamSwitch,
-        navigateToTeamPage,
+        navigateToGamePage,
         isAllReady, countdown,
         stompClient
     };

--- a/src/modules/room/components/attack/attack.tsx
+++ b/src/modules/room/components/attack/attack.tsx
@@ -9,12 +9,13 @@ import { TeamHeaderComponent } from "../../../quiz/components/multi/TeamHeader/T
 import { UserTagsComponent } from "../../../quiz/components/multi/UserTags/UserTags";
 import { MultiGameBackground, MultiGameAttackContainer, MutliGameAttackTimerWrap, MultiGameAttackTimer, MultiGameAttackTimerText, MultiGameAttackQuizContainer, MultiGameAttackQuizWrap, MultiGameAttackQuiz, MultiGameAttackQuizCheckbox, MultiGameAttackButtonWrap } from "./styled";
 import { Quiz } from "../../../../types/quiz";
+import { useRoom } from "../../../../hook/useRoom";
 
 interface AttackPageProps {
     onSelectionComplete: (quiz: Quiz) => void;
 }
 
-export default function AttackPage({ onSelectionComplete }: AttackPageProps) {
+export default function AttackPage({ onSelectionComplete }: AttackPageProps, roomId: string) {
     const [teamId, setTeamId] = useState(1);
     const [isAttackTeam, setIsAttackTeam] = useState(true);
     const customConfirm = useConfirm(); 
@@ -23,6 +24,7 @@ export default function AttackPage({ onSelectionComplete }: AttackPageProps) {
     const [selectedCategory, setSelectedCategory] = useState("OS");
     const [selectedQuizId, setSelectedQuizId] = useState<number | null>(null);
     const fetchCalled = useRef(false); // API 중복 호출 방지용 ref
+    const {exitRoom} = useRoom(roomId);
 
     useEffect(() => {
         if (timeLeft > 0) {
@@ -40,7 +42,10 @@ export default function AttackPage({ onSelectionComplete }: AttackPageProps) {
         const confirmed = await customConfirm("정말 나가시겠습니까?");
         if (confirmed) {
             console.log("나감");  // TODO: 방 나감
+            exitRoom();
         }
+
+
     };
 
     useEffect(() => {

--- a/src/modules/room/components/attack/attack.tsx
+++ b/src/modules/room/components/attack/attack.tsx
@@ -44,8 +44,6 @@ export default function AttackPage({ onSelectionComplete }: AttackPageProps, roo
             console.log("나감");  // TODO: 방 나감
             exitRoom();
         }
-
-
     };
 
     useEffect(() => {

--- a/src/modules/room/components/solving/solving.tsx
+++ b/src/modules/room/components/solving/solving.tsx
@@ -24,9 +24,8 @@ export const SolvingPage = ({ selectedQuiz }: { selectedQuiz: any }, roomId: str
         const confirmed = await customConfirm("정말 나가시겠습니까?");
         if (confirmed) {
             console.log("나감");  // TODO: 방 나감
+            exitRoom();
         }
-
-        exitRoom();
     };
 
     return(

--- a/src/modules/room/components/solving/solving.tsx
+++ b/src/modules/room/components/solving/solving.tsx
@@ -9,10 +9,12 @@ import { UserTagsComponent } from "../../../../modules/quiz/components/multi/Use
 import { SolvingBottom, SolvingContainer, SovlingInput, SovlingInputWrap } from "./styled";
 import { SolvingHeaderComponent } from "../../../../modules/quiz/components/multi/SolvingHeader/SolvingHeader";
 import { useConfirm } from "../../../../components/confirmPopup";
+import { useRoom } from "../../../../hook/useRoom";
 
-export const SolvingPage = ({ selectedQuiz }: { selectedQuiz: any }) => {
+export const SolvingPage = ({ selectedQuiz }: { selectedQuiz: any }, roomId: string) => {
     const [teamId, setTeamId] = useState(2);
     const customConfirm = useConfirm(); 
+    const {exitRoom} = useRoom(roomId);
 
     const handleSubmitAnswer = () => {
         console.log("제출")
@@ -23,6 +25,8 @@ export const SolvingPage = ({ selectedQuiz }: { selectedQuiz: any }) => {
         if (confirmed) {
             console.log("나감");  // TODO: 방 나감
         }
+
+        exitRoom();
     };
 
     return(

--- a/src/pages/multi/defend/select/select.tsx
+++ b/src/pages/multi/defend/select/select.tsx
@@ -6,9 +6,11 @@ import { TeamHeaderTag } from "../../../../modules/quiz/components/multi/TeamHea
 import { UserTagsComponent } from "../../../../modules/quiz/components/multi/UserTags/UserTags"
 import AnswerSelectComponent from "../../../../modules/quiz/components/multi/Answer/AnswerSelect"
 import { SelectAnswerButtonWrap, SelectAnswerContainer } from "./styled"
+import { useRoom } from "../../../../hook/useRoom";
 
-export const SelectAnswerPage = () => {
+export const SelectAnswerPage = (roomId : string) => {
     const [teamId, setTeamId] = useState(2);
+    const {exitRoom} = useRoom(roomId);
     return(
         <Background>
             <TeamHeaderTag teamId={teamId}>{teamId}팀</TeamHeaderTag>
@@ -16,7 +18,7 @@ export const SelectAnswerPage = () => {
                     <SolvingHeaderComponent />
                 <AnswerSelectComponent />
                     <SelectAnswerButtonWrap>
-                        <SecondaryButtonSmall>나가기</SecondaryButtonSmall>
+                        <SecondaryButtonSmall onClick= {exitRoom}>나가기</SecondaryButtonSmall>
                         <BlackButtonSmall>선택완료</BlackButtonSmall>
                     </SelectAnswerButtonWrap>
                 <UserTagsComponent teamId={teamId}  />

--- a/src/pages/multi/defend/select/select.tsx
+++ b/src/pages/multi/defend/select/select.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { useLocation } from 'react-router-dom';
 import { Background } from "../../../../components/background/styled"
 import { BlackButtonSmall, SecondaryButtonSmall } from "../../../../components/buttons/styled"
 import { SolvingHeaderComponent } from "../../../../modules/quiz/components/multi/SolvingHeader/SolvingHeader"
@@ -8,7 +9,8 @@ import AnswerSelectComponent from "../../../../modules/quiz/components/multi/Ans
 import { SelectAnswerButtonWrap, SelectAnswerContainer } from "./styled"
 import { useRoom } from "../../../../hook/useRoom";
 
-export const SelectAnswerPage = (roomId : string) => {
+export const SelectAnswerPage = () => {
+    const { roomId } = useLocation().state;
     const [teamId, setTeamId] = useState(2);
     const {exitRoom} = useRoom(roomId);
     return(

--- a/src/pages/multi/room/room.tsx
+++ b/src/pages/multi/room/room.tsx
@@ -19,7 +19,7 @@ export default function Room() {
   const { state } = useLocation();
   const {
     teamOneUsers, teamTwoUsers,
-    userReady, exitRoom, teamSwitch,navigateToTeamPage,
+    userReady, exitRoom, teamSwitch,navigateToGamePage,
     countdown, stompClient, isAllReady
   } = useRoom(roomId);
 
@@ -107,7 +107,7 @@ export default function Room() {
           onClose={() => {
             setIsFirstAttackModalOpen(false)
             
-            navigateToTeamPage(); // 팀 별로 다른 페이지 리다이렉트
+            navigateToGamePage(); // 팀 별로 다른 페이지 리다이렉트
           }}
         />
       )}

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -8,6 +8,7 @@ export enum GameReadyEvents {
 
 // 게임 상태도 상수로 관리
 export enum GameStatus {
+    READY = 'READY',
     START = 'START',
     WAITING = 'WAITING',
     COUNTDOWN = 'COUNTDOWN',


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점
1. `useRoom` 훅을 다른 페이지에서 사용할 수 있도록 리펙토링
`useRoom()` 훅은 ROOM에서 사용하는 함수들을 정의 해놓음. useRoom에서 멀티게임과 관련된 소켓 연결을 관리하고 그와 관련된 이벤트 함수들을 관리함. 따라서 앞으로 쓰일 게임 페이지에서도 `useRoom()` 훅이 사용될 것을 고려해 상태관리 변수를 추가하였습니다.
```
//src/types/game.ts
export enum GameStatus {
    READY = 'READY',
    START = 'START',
    WAITING = 'WAITING',
    COUNTDOWN = 'COUNTDOWN',
    PLAYING = 'PLAYING',
    ENDED = 'ENDED'
} ;
```

이 상태값을 통해서 `useRoom`의 `useEffect` 훅의 로직을 게임 상태에 맞게 컨트롤 할 수 있습니다.
```
 useEffect(() => {
        // 게임 준비 상태일 때만. 해당 훅을 실행한다.  다른 페이지에서 useRoom 훅을 호출해도 해당 훅은 실행되지 않는다.
        if(gameState !== GameStatus.READY) return;
        if (Connected.current) return;
      // 준비 방 정보와 소켓 연결을 초기화하는 코드들...
       <---생략--->
    }, [roomId]);
```

2. `useRoom` 훅을 통한 exit 함수 매핑
```
//src/module/room/conponent/Attack.tsx
 const {exitRoom} = useRoom(roomId); // useRoom 훅 호출.

  const handleLeaveRoom = async () => {
        const confirmed = await customConfirm("정말 나가시겠습니까?");
        if (confirmed) {
            console.log("나감");  // TODO: 방 나감
            exitRoom(); //useRoom의 exit 함수 재사용
        }
    };
```

```
//src/page/multi/defend/select/select.tsx
import { useRoom } from "../../../../hook/useRoom";

export const SelectAnswerPage = (roomId : string) => {
    const [teamId, setTeamId] = useState(2);
    const {exitRoom} = useRoom(roomId);
    return(
        <Background>
            <---생략--->
                    <SecondaryButtonSmall onClick= {exitRoom}>나가기</SecondaryButtonSmall>
            <---생략--->
        </Background>
    )
}
```

3. 선공선점 이벤트가 끝난 후, 해당 방 번호를 게임 페이지에 전달합니다.
```
// TODO: Team 나눠서 페이지 이동하는 함수 
    const navigateToGamePage = async () => {
        //GameStart 상태로 만들어줌.
        handleReadyRoomEvent(GameReadyEvents.GAME_START);

        // Navigate Game Page
        navigate("/multi/game", {
            state: {
                roomId // Attack과 Defence 페이지에 roomId 전달.
            }
        });
    };
```

선공 팀 결과모달이 닫힐 때 다른 페이지로 이동합니다.
```
{isFirstAttackModalOpen && firstAttackTeam && (
        <FirstAttackModal
          team={firstAttackTeam}
          onClose={() => {
            setIsFirstAttackModalOpen(false)
            
            navigateToGamePage(); 
          }}
        />
      )}
```

4. app.tsx 수정
```
<Route
          path="/multi/defend/select/:id"
          element={
            <ProtectedRoute>
              <SelectAnswerPage />
            </ProtectedRoute>
          }
```
roomUse 훅을 쓰려면 roomId가 필요한데, exit 버튼 구현이 필요한 페이지가 app.tsx에 라우트 되어 있어서,
 uselocation 훅을 통해서 `:id`로 roomId 를 전달하도록 수정.

## 💬리뷰 요구사항(선택)
공격 화면에서는 잘 나가지는 거 확인~
수비는....해볼게요..잠시만요.
