### PR TITLE
143 multi 공격팀 선택 수비에게 전달하기

### DIFF
--- a/src/config/websocket/constants.ts
+++ b/src/config/websocket/constants.ts
@@ -15,7 +15,9 @@ export const SOCKET_DESTINATIONS = {
                 GAME_STATE : (roomId : string )=> `/topic/game/${roomId}/general`,
 
                 // 사용자 입력 실시간 공유
-                LEADER_SELECT_QUIZE: (roomId:string, team:string) =>  `/topic/game/${roomId}/${team}`,// 공격팀 리더의 퀴즈 주제 선택 공유
+                LEADER_SELECT_QUIZE: (roomId:string) =>  `/topic/game/${roomId}/select/option`,// 공격팀 리더의 퀴즈 주제 선택 공유
+                // 리더 최종 선택 공우
+                LEADER_FINAL_SELECT : (roomId:string) => `/topic/game/${roomId}/select/quiz`,
 
                 // HP 업데이트 구독
                 UPDATE_HP :  (roomId:string) => `/topic/game/${roomId}/general`

--- a/src/hook/useRoom.tsx
+++ b/src/hook/useRoom.tsx
@@ -148,6 +148,9 @@ export const useRoom = (roomId: string) => {
             // 또는 다른 에러 처리
         }
 
+        
+
+
         // Navigate Game Page
         navigate("/multi/game");
     };

--- a/src/modules/room/components/attack/attack.tsx
+++ b/src/modules/room/components/attack/attack.tsx
@@ -93,30 +93,10 @@ export default function AttackPage({ onSelectionComplete }: AttackPageProps) {
                 console.error("Error fetching quiz data:", error);
             }
 
-            subscribeData(); // FIXME: 혹시 비동기 문제가 있는지 체크하기.
+            
         };
 
-        const subscribeData = async () => {
-            try {
-                const client = stompClient.current;
-                if (!client) {
-                    throw new Error('Stomp client is not initialized');
-                }
-
-                await new Promise<void>((resolve) => {
-                    gameRoomSocketEvents.subscribeLeaderSelect(
-                        client,  // null이 아님이 확인된 client 사용
-                        _roomId,
-                        teamId === 1 ? 'blue' : 'red',
-                        initLeaderSelectQuizeId
-                    );
-                    resolve();
-                });
-            } catch (error) {
-                console.error('subscribe leader select failed:', error);
-                throw error;
-            }
-        };
+        
 
         fetchQuizData();
         

--- a/src/modules/room/components/attack/attack.tsx
+++ b/src/modules/room/components/attack/attack.tsx
@@ -107,10 +107,9 @@ export default function AttackPage({ onSelectionComplete }: AttackPageProps) {
 
     const handleSelectionComplete = () => {
         if(user?.isLeader == 1) return;
-
-        const selectedQuiz = quizData.find(quiz => quiz.quizId === selectedQuizId);
-        if (selectedQuiz) {
-            onSelectionComplete(selectedQuiz); // 상위 컴포넌트에 선택된 문제 전달
+        
+        if (selectedQuizId) {
+            gameRoomSocketEvents.selectQuizeLeaderFinal(stompClient, _roomId, selectedQuizId );
         }
     };
 

--- a/src/modules/room/components/attack/attack.tsx
+++ b/src/modules/room/components/attack/attack.tsx
@@ -107,9 +107,11 @@ export default function AttackPage({ onSelectionComplete }: AttackPageProps) {
 
     const handleSelectionComplete = () => {
         if(user?.isLeader == 1) return;
-        
-        if (selectedQuizId) {
+
+        const selectedQuiz = quizData.find(quiz => quiz.quizId === selectedQuizId);
+        if (selectedQuizId && selectedQuiz) {
             gameRoomSocketEvents.selectQuizeLeaderFinal(stompClient, _roomId, selectedQuizId );
+            onSelectionComplete(selectedQuiz);
         }
     };
 

--- a/src/pages/multi/defend/defend.tsx
+++ b/src/pages/multi/defend/defend.tsx
@@ -3,18 +3,19 @@ import { TeamHeaderComponent } from "../../../modules/quiz/components/multi/Team
 import { Background } from "../../../components/background/styled";
 import { WaitingScreen } from "../../../modules/quiz/components/multi/waiting/WaitingScreen";
 import { UserTagsComponent } from "../../../modules/quiz/components/multi/UserTags/UserTags";
-
-
+import { useGameUser } from "../../../contexts/GameUserContext/useGameUser";
+import { useTeamState } from "../../../contexts/TeamStateContext/useTeamState";
 export default function DefendPage() {
     //수비팀 선택
-    const [teamId, setTeamId] = useState(2);
-    const [isAttackTeam, setIsAttackTeam] = useState(false);
-    
-    return(
+    const { user } = useGameUser();
+    const teamId = user?.team == 'BLUE' ? 1 : 2;
+    const { attackTeam } = useTeamState();
+
+    return (
         <Background>
-            <TeamHeaderComponent teamId={teamId} isAttackTeam={isAttackTeam} />
+            <TeamHeaderComponent teamId={teamId} isAttackTeam={user?.team == attackTeam ? true : false} />
             <WaitingScreen teamId={teamId} />
-            <UserTagsComponent teamId={teamId}/>
+            <UserTagsComponent teamId={teamId} />
         </Background>
     )
 }

--- a/src/pages/multi/game/quizGame.tsx
+++ b/src/pages/multi/game/quizGame.tsx
@@ -20,7 +20,6 @@ export default function QuizGamePage() {
     const { user, fetchUserGameProfile } = useGameUser();
     const { attackTeam } = useTeamState();
     const [userLoaded, setUserLoaded] = useState(false);  // 유저 정보 로딩 상태 추가
-    const teamId = user?.team == 'BLUE' ? 1 : 2;
 
     const handleCompleteSelection = (quiz: Quiz) => {
         setSelectedQuiz(quiz);
@@ -55,11 +54,11 @@ export default function QuizGamePage() {
                     gameRoomSocketEvents.subscribeLeaderSelect(
                         client,  // null이 아님이 확인된 client 사용
                         _roomId,
-                        teamId === 1 ? 'blue' : 'red',
                         initLeaderSelectQuizeId
                     );
                     resolve();
                 });
+                setIsLoaded();
             } catch (error) {
                 console.error('subscribe leader select failed:', error);
                 throw error;
@@ -76,11 +75,11 @@ export default function QuizGamePage() {
                     gameRoomSocketEvents.subscribeLeaderFinalSelect(
                         client,  // null이 아님이 확인된 client 사용
                         _roomId,
-                        teamId === 1 ? 'blue' : 'red',
                         handleCompleteSelection
                     );
                     resolve();
                 });
+                setIsLoaded();
             } catch (error) {
                 console.error('subscribe leader select failed:', error);
                 throw error;
@@ -101,7 +100,7 @@ export default function QuizGamePage() {
         if (isLoading) {
             setUpGameRoom();
         }
-    }, [isLoading, roomUserId, fetchUserGameProfile, setIsLoaded]);
+    }, []);
 
     // 로딩 중이거나 유저 정보가 없으면 로딩 화면 표시
     if (isLoading || !userLoaded || !user) {

--- a/src/pages/multi/room/room.tsx
+++ b/src/pages/multi/room/room.tsx
@@ -34,6 +34,8 @@ export default function Room() {
     if (isAllReady) {
       // 5초 카운트다운 모달 시작
       setIsCountDownModalOpen(true);
+      // 무작위로 선공 팀 결정
+      getFirstAttackTeam();
       setTimeLeft(5); // 카운트다운 초기화
       const countdownTimer = setInterval(() => {
         setTimeLeft((prev) => {
@@ -59,15 +61,42 @@ export default function Room() {
     if (isCoinAnimation) {
       const animationTimer = setTimeout(() => {
         setIsCoinAnimation(false);
-        // 무작위로 선공 팀 결정
-        const selectedTeam = '1팀';   // 백엔드에서 랜덤 받아와야 할 듯!
-        setFirstAttackTeam(selectedTeam);
+       
         setIsFirstAttackModalOpen(true);
       }, 5000);
       return () => clearTimeout(animationTimer);
     }
   }, [isCoinAnimation]);
 
+  const getFirstAttackTeam = async () => {
+    const userUuid = localStorage.getItem("uuid");
+    const userAccessToken = localStorage.getItem("AccessToken");
+    const API_URL = `/api/quiz/multi/game/start`;
+
+    try {
+      const response = await fetch(API_URL, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${userAccessToken}`,
+          "uuid": `${userUuid}`,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          roomId: roomId,
+          gameStatus: "GAME_START"
+        })
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        const selectedTeam = data.data.teamColor ===  "BLUE" ?'1팀' : '2팀';   // 백엔드에서 랜덤 받아와야 할 듯!
+        setFirstAttackTeam(selectedTeam);
+      }
+
+    } catch (error) {
+      console.error("선공팀을 받아오는데 실패하였습니다.", error);
+    }
+  }
 
   if (!isTeamsLoaded) {
     return <div>Loading teams...</div>;


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점
1. Defence Page도 전역 user Team 받아와서 동적으로 랜더링 하도록 수정
2. 공격 팀리더 선택 구독 함수 경로 수정
3. 공격 팀 리더 최종 문제 선택 후 수비 팀 구독 메세지 Quize으로 파싱 구현
4. 공격 팀 리더 최종 문제 선택 후 Game Status 바뀌도록 수정.
 ```
const handleSelectionComplete = () => {
        if(user?.isLeader == 1) return; // 팀 리더만 최종 선택이 가능하다.

        const selectedQuiz = quizData.find(quiz => quiz.quizId === selectedQuizId);
        if (selectedQuizId && selectedQuiz) {
            gameRoomSocketEvents.selectQuizeLeaderFinal(stompClient, _roomId, selectedQuizId );
            onSelectionComplete(selectedQuiz);
        }
    };
```