### PR TITLE
Fix: 유저 정보 클릭 후 모달 창 안닫히는 오류 해결

### DIFF
--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -17,6 +17,7 @@ export interface IModalProps {
   $transform?: string;
   $padding ?:string;
   selectedQuiz ?: any;
+  closeOnBackdropClick?: boolean; // closeOnBackdropClick이 true일 때만 onClose 호출
 }
 
 export const Modal = ({
@@ -35,11 +36,14 @@ export const Modal = ({
   $border,
   $transform,
   $padding,
+  closeOnBackdropClick = false, // 기본값은 false
 }: IModalProps & { children: ReactNode }) => {
   return (
     <Fragment>
       {backdrop && (
-        <ModalBackdrop $open={open} $backdropcolor = {backdropcolor} />
+        <ModalBackdrop $open={open} $backdropcolor = {backdropcolor}
+        onClick={closeOnBackdropClick ? onClose : undefined} // closeOnBackdropClick이 true일 때만 onClose 호출
+        />
       )}
        <ModalBase
         $open={open}

--- a/src/components/modal/room/usercontrol/index.tsx
+++ b/src/components/modal/room/usercontrol/index.tsx
@@ -2,7 +2,7 @@ import { Client, Stomp } from "@stomp/stompjs";
 import { Modal, IModalProps } from "../..";
 import { readyRoomSocketEvents } from "../../../../hook/readyRoomSocketEvent";
 import { UserControlWrap, UserControlBtn, UserControlKickBtn } from "./styled";
-import React, { useState } from "react";
+import { useState } from "react";
 
 interface UserControlInRoomProps extends IModalProps {
   user: any; // 유저 정보 타입 => 수정 필요
@@ -41,7 +41,7 @@ export const UserControlInRoom = ({
       $transform="translate(0, 0)" 
       $round = "0px"
       $border = "1px solid #333"
-      $padding = "10px 10px"
+      $padding = "10px 10px"closeOnBackdropClick={true} // 외부 클릭 닫기로 활성화
     >
       <UserControlWrap>
         <div style={{ fontWeight: 'bold' }}>{user?.name}</div>


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [x] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점

기존에 Modal 창 옵션이 창 밖 화면을 클릭했을 때 클릭이 되지 않게 하는 것을 false로 해서
모달 창 끄고 싶은 것들만 closeOnBackdropClick={true} 컴포넌트에 추가만 하시면 추후에도 사용이 가능합니다.