### PR TITLE
Fix: 마이페이지 경고창 추가

### DIFF
--- a/src/pages/mypage/addProblem/addProblem.tsx
+++ b/src/pages/mypage/addProblem/addProblem.tsx
@@ -8,6 +8,7 @@ import { AddProblemModal } from "../../../components/modal/mypage/addQuesttion";
 import { LoadingQuestion } from "./LoadingQuestion";
 import useButtonSoundEffect from "../../../hook/useHoverSoundEffect";
 import { Tooltip } from "react-tooltip";
+import { useConfirm } from "../../../components/confirmPopup";
 
 export default function AddProblemPage() {
     const navigate = useNavigate();
@@ -20,17 +21,32 @@ export default function AddProblemPage() {
     const [modalData, setModalData] = useState([]);
     const [loadingQuestion, setLoadingQuestion] = useState(false);
     useButtonSoundEffect()
+    const customAlert = useConfirm();
 
     const handleCancel = () => {
         navigate("/mypage");
     };
 
     const handleOpenModal = async () => {
+        // 문제 내용 입력 여부 확인
+        if (!problemContent.trim()) {
+            customAlert("작성한 내용이 없습니다.");
+            return;
+        }
+
+        // 문제 수가 0 이하인 경우 확인
+        if (value <= 0) {
+            customAlert("한 문제이상으로 설정해 주세요.");
+            return;
+        }
+
         setLoadingQuestion(true);
         const successModal = await sendTextQuiz();
         setLoadingQuestion(false);
         if (successModal) {
             setIsModalOpen(true);
+        } else {
+            customAlert("문제 생성에 실패하였습니다. 다른 내용을 입력해주세요.");
         }
     };
     const handleCloseModal = () => {
@@ -112,7 +128,7 @@ export default function AddProblemPage() {
                                 data-tooltip-id="tooltip"
                             />
                             <Tooltip id="tooltip" place="bottom" className="tooltip-custom">
-                                공부할 때 참고했던 블로그나 글을 복사해서<br />
+                                공부할 때 참고했던 링크나 글을 복사해서 <br />
                                 입력하면 그에 맞는 문제가 출제가 됩니다.<br />
                                 선택한 종류와 문제수에 맞게 생성이 됩니다.
                             </Tooltip>


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점

마이 페이지 문제 등록하기 페이지에서 문제 수를 0으로 입력하거나 내용을 입력하지 않은 경우, 생성에 실패한 경우 경고창 생성하였습니다.

추가로 제출하기 모달창이 떴을 때, 취소하기 버튼을 누르면 내용만 초기화하려고 세팅 해보았으나, 계속 생성실패 오류 경고창이 뜨는 문제로 기존에 있던 window.location.reload(); 를 사용하기로 결정하였습니다.